### PR TITLE
Create B3

### DIFF
--- a/Bakers/B3/create B3
+++ b/Bakers/B3/create B3
@@ -1,0 +1,3 @@
+node ID: c041c7efa83e6211
+restart using local DB: catch time is 60 minutes at a block height of 123413
+restart no-block-state-import: catch time is 120 minutes at a block height of 124480


### PR DESCRIPTION
node ID: c041c7efa83e6211
restart using local DB: catch time is 60 minutes at a block height of 123413
restart no-block-state-import: catch time is 120 minutes at a block height of 124480
[concordium-testnet-system-report.log](https://github.com/Concordium/Testnet3-Challenges/files/5418314/concordium-testnet-system-report.log)
[concordium-testnet-node.log](https://github.com/huba-buba/Testnet3-Challenges/commit/c99044fbe4c20e5981bcf6cbc36e0070662e54ad)


