### PR TITLE
Create B3 Julyla

### DIFF
--- a/Bakers/B3/B3 Julyla
+++ b/Bakers/B3/B3 Julyla
@@ -1,0 +1,5 @@
+node ID: 352bf3ceebe47ea2
+restart using local DB: catch time is 35 minutes at a block height of 123342
+restart no-block-state-import: catch time is 64 minutes at a block height of 125454
+
+[logfiles](https://github.com/Julyla/Testnet3-Challenges/commit/5e5b3754833ff6e465cd4dd9bb64c15311657353)


### PR DESCRIPTION
node ID: 352bf3ceebe47ea2
restart using local DB: catch time is 35 minutes at a block height of 123342
restart no-block-state-import: catch time is 64 minutes at a block height of 125454
[log files](https://github.com/Julyla/Testnet3-Challenges/commit/5e5b3754833ff6e465cd4dd9bb64c15311657353)