### PR TITLE
Create B3 bukala

### DIFF
--- a/Bakers/B3/B3 bukala
+++ b/Bakers/B3/B3 bukala
@@ -1,0 +1,4 @@
+node ID: d23666cf32f97af2
+restart using local DB: catch time is 42 minutes at a block height of 123371
+restart no-block-state-import: catch time is 74 minutes at a block height of 125520
+[log files](https://github.com/bukala/Testnet3-Challenges/find/new_branch)


### PR DESCRIPTION
node ID: d23666cf32f97af2
restart using local DB: catch time is 42 minutes at a block height of 123371
restart no-block-state-import: catch time is 74 minutes at a block height of 125520
[log files](https://github.com/bukala/Testnet3-Challenges/find/new_branch)